### PR TITLE
Create user based on ENV variables PUID & PGID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,13 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
+ENV PUID=1000
+ENV PGID=1000
+
 # setup steam user
-RUN useradd -m steam
+RUN groupadd --gid "${PGID}" -r steam 
+RUN useradd -u "${PUID}" -r -g "${PGID}" -m -d /home/steam -c "Valheim server user" steam
 WORKDIR /home/steam
-USER steam
 
 RUN mkdir server_scripts
 COPY server.sh server_scripts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,16 +6,11 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/
 
-ENV PUID=1000
-ENV PGID=1000
-
 # setup steam user
-RUN groupadd --gid "${PGID}" -r steam 
-RUN useradd -u "${PUID}" -r -g "${PGID}" -m -d /home/steam -c "Valheim server user" steam
+RUN useradd -m steam
 WORKDIR /home/steam
 
-RUN mkdir server_scripts
-COPY server.sh server_scripts/
+COPY server.sh .
 
 # download steamcmd
 RUN mkdir steamcmd && cd steamcmd && \
@@ -27,5 +22,5 @@ RUN ./steamcmd/steamcmd.sh +quit && \
     ln -s /home/steam/steamcmd/linux32/steamclient.so /home/steam/.steam/sdk32/steamclient.so
 
 # start the server main script
-ENTRYPOINT ["bash", "/home/steam/server_scripts/server.sh"]
+ENTRYPOINT ["bash", "/home/steam/server.sh"]
 

--- a/server.sh
+++ b/server.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+usermod -u ${PUID} steam
+groupmod -g ${PGID} steam
+su -s /bin/bash -c 'id' steam
+
 # update server's data
 /home/steam/steamcmd/steamcmd.sh \
 	    +login anonymous \

--- a/server.sh
+++ b/server.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
 usermod -u ${PUID} steam
 groupmod -g ${PGID} steam
 su -s /bin/bash -c 'id' steam


### PR DESCRIPTION
This helps on (NAS) systems with additional ACLs and prevents disk write failures.

Use UID and GID from a host user with RW permissions on mounted folders as ENV variables PGID and PUID

You can find out UID/GID via `id <username>`